### PR TITLE
Adding documentation for the indexing components.

### DIFF
--- a/src/data/collection.jl
+++ b/src/data/collection.jl
@@ -1,5 +1,34 @@
-# for now, we load collections in memory.
-# will be good to implement on-disk data structures too.
+# TODO: implement on-disk collections, and the case where pids are not necessarily sorted and can be arbitrary
+"""
+    Collection(path::String)
+
+A wrapper around a collection of documents, which stores the underlying collection as a `Vector{String}`.
+
+# Arguments
+
+- `path::String`:   A path to the document dataset. It is assumed that `path` refers to a CSV file. Each line of the
+                    the CSV file should be of the form `pid \\t document`, where `pid` is the integer index of the document. `pid`s should be in the range ``[1, N]``, where ``N`` is the number of documents, and should be sorted.
+
+# Examples
+
+Here's an example which loads a small subset of the LoTTe dataset defined in `short_collections.tsv` (see the `examples` folder in the package).
+
+```julia-repl
+julia> using ColBERT;
+
+julia> dataroot = "downloads/lotte";
+
+julia> dataset = "lifestyle";
+
+julia> datasplit = "dev";
+
+julia> path = joinpath(dataroot, dataset, datasplit, "short_collection.tsv")
+"downloads/lotte/lifestyle/dev/short_collection.tsv"
+
+julia> collection = Collection(path)
+Collection at downloads/lotte/lifestyle/dev/short_collection.tsv with 10 passages.
+```
+"""
 struct Collection
     path::String
     data::Vector{String}
@@ -12,10 +41,52 @@ function Collection(path::String)
     Collection(path, file.text)
 end
 
+"""
+    get_chunksize(collection::Collection, nranks::Int)
+
+Determine the size of chunks used to store the index, based on the size of the `collection` and the number of available GPUs.
+
+# Arguments
+
+- `collection::Collection`: The underlying collection of documents. 
+- `nranks::Int`: Number of available GPUs to compute the index. At this point, the package only supports `nranks = 1`.
+
+# Examples
+
+Continuing from the example from the [`Collection`](@ref) constructor:
+
+```julia-repl
+julia> get_chunksize(collection, 1) 
+11
+```
+"""
 function get_chunksize(collection::Collection, nranks::Int)
     Int(min(25000, 1 + floor(length(collection.data) / nranks)))
 end
 
+"""
+    enumerate_batches(collection::Collection; [chunksize, nranks])
+
+Batch the `collection` into chunks containing tuples of the form `(chunk_idx, offset, passages)`, where `chunk_idx` is the index of the chunk, `offset` is the index of the first passsage in the chunk, and `passages` is a `Vector{String}` containing the passages in the chunk.
+
+# Arguments
+
+- `collection::Collection`: The collection to batch.
+- `chunksize::Union{Int, Missing}`: The chunksize to use to batch the collection. Default `missing`. If this is `missing`, then `chunksize` is determined using [`get_chunksize`](@ref) based on the `collection` and `nranks`.
+- `nranks::Union{Int, Missing}`: The number of available GPUs. Default `missing`. Currently the package only supports `nranks = 1`.
+
+The `collection` is batched into chunks of uniform size (with the last chunk potentially having a smaller size).
+
+# Examples
+
+Continuing from the example in the [`Collection`](@ref) constructor.
+
+```julia-repl
+julia> enumerate_batches(collection; nranks = 1);
+
+julia> enumerate_batches(collection; chunksize = 3); 
+```
+"""
 function enumerate_batches(
         collection::Collection; chunksize::Union{Int, Missing} = missing,
         nranks::Union{Int, Missing} = missing)
@@ -41,4 +112,8 @@ function enumerate_batches(
         end
     end
     batches
+end
+
+function Base.show(io::IO, collection::Collection)
+    print(io, "Collection at $(collection.path) with $(length(collection.data)) passages.")
 end

--- a/src/indexing/codecs/residual.jl
+++ b/src/indexing/codecs/residual.jl
@@ -54,6 +54,7 @@ function compress_into_codes(codec::ResidualCodec, embs::Matrix{Float64})
         offset += bsize
     end
 
+    @assert length(codes) == size(embs)[2]
     codes
 end
 

--- a/src/indexing/codecs/residual.jl
+++ b/src/indexing/codecs/residual.jl
@@ -10,7 +10,7 @@ It stores information about the configuration of the model, the centroids used t
 # Arguments
 
 - `config`: A [`ColBERTConfig`](@ref), representing all configuration parameters related to various ColBERT components.
-- `centroids`: A matrix of centroids used to quantize the residuals.
+- `centroids`: A matrix of centroids used to quantize the residuals. Has shape `(D, N)`, where `D` is the embedding dimension and `N` is the number of clusters.
 - `avg_residual`: The average residual value.
 - `bucket_cutoffs`: A vector of cutoff values used to determine which buckets each residual belongs to.
 - `bucket_weights`: A vector of weights used to determine the importance of each bucket.

--- a/src/indexing/codecs/residual.jl
+++ b/src/indexing/codecs/residual.jl
@@ -95,7 +95,6 @@ function binarize(codec::ResidualCodec, residuals::Matrix{Float64})
     residuals_packed = reshape(residuals_packed, (Int(dim / 8) * nbits, num_embeddings)) # reshape back to get compressions for each embedding
 end
 
-
 """
     compress(codec::ResidualCodec, embs::Matrix{Float64})
 

--- a/src/indexing/codecs/residual.jl
+++ b/src/indexing/codecs/residual.jl
@@ -1,5 +1,24 @@
 using .ColBERT: ColBERTConfig 
 
+"""
+    ResidualCodec(config::ColBERTConfig, centroids::Matrix{Float64}, avg_residual::Float64, bucket_cutoffs::Vector{Float64}, bucket_weights::Vector{Float64})
+
+A struct that represents a compressor for ColBERT embeddings. 
+
+It stores information about the configuration of the model, the centroids used to quantize the residuals, the average residual value, and the cutoffs and weights used to determine which buckets each residual belongs to.
+
+# Arguments
+
+- `config`: A [`ColBERTConfig`](@ref), representing all configuration parameters related to various ColBERT components.
+- `centroids`: A matrix of centroids used to quantize the residuals.
+- `avg_residual`: The average residual value.
+- `bucket_cutoffs`: A vector of cutoff values used to determine which buckets each residual belongs to.
+- `bucket_weights`: A vector of weights used to determine the importance of each bucket.
+
+# Returns
+
+A `ResidualCodec` object.
+"""
 mutable struct ResidualCodec
     config::ColBERTConfig
     centroids::Matrix{Float64}
@@ -8,6 +27,21 @@ mutable struct ResidualCodec
     bucket_weights::Vector{Float64}
 end
 
+"""
+    compress_into_codes(codec::ResidualCodec, embs::Matrix{Float64})
+
+Compresses a matrix of embeddings into a vector of codes using the given [`ResidualCodec`](@ref), where the code for each embedding is its nearest centroid ID. 
+
+# Arguments
+
+- `codec`: The [`ResidualCodec`](@ref) used to compress the embeddings.
+- `embs`: The matrix of embeddings to be compressed.
+
+# Returns
+
+A vector of codes, where each code corresponds to the nearest centroid ID for the embedding.
+```
+"""
 function compress_into_codes(codec::ResidualCodec, embs::Matrix{Float64})
     codes = []
 
@@ -23,6 +57,20 @@ function compress_into_codes(codec::ResidualCodec, embs::Matrix{Float64})
     codes
 end
 
+"""
+    binarize(codec::ResidualCodec, residuals::Matrix{Float64})
+
+Convert a matrix of residual vectors into a matrix of integer residual vector using `nbits` bits (specified by the underlying `config`). 
+
+# Arguments
+
+- `codec`: A [`ResidualCodec`](@ref) object containing the compression information. 
+- `residuals`: The matrix of residuals to be converted.
+
+# Returns
+
+A matrix of compressed integer residual vectors. 
+"""
 function binarize(codec::ResidualCodec, residuals::Matrix{Float64})
     dim = codec.config.doc_settings.dim
     nbits = codec.config.indexing_settings.nbits
@@ -46,6 +94,23 @@ function binarize(codec::ResidualCodec, residuals::Matrix{Float64})
     residuals_packed = reshape(residuals_packed, (Int(dim / 8) * nbits, num_embeddings)) # reshape back to get compressions for each embedding
 end
 
+
+"""
+    compress(codec::ResidualCodec, embs::Matrix{Float64})
+
+Compress a matrix of embeddings into a compact representation using the specified [`ResidualCodec`](@ref). 
+
+All embeddings are compressed to their nearest centroid IDs and their quantized residual vectors (where the quantization is done in `nbits` bits, specified by the `config` of  `codec`). If `emb` denotes an embedding and `centroid` is is nearest centroid, the residual vector is defined to be `emb - centroid`.
+
+# Arguments
+
+- `codec`: A [`ResidualCodec`](@ref) object containing the centroids and other parameters for the compression algorithm.
+- `embs`: The input embeddings to be compressed.
+
+# Returns
+
+A tuple containing a vector of codes and the compressed residuals matrix.
+"""
 function compress(codec::ResidualCodec, embs::Matrix{Float64})
     codes, residuals = Vector{Int}(), Vector{Matrix{UInt8}}() 
 
@@ -65,6 +130,21 @@ function compress(codec::ResidualCodec, embs::Matrix{Float64})
     codes, residuals
 end
 
+"""
+    load_codes(codec::ResidualCodec, chunk_idx::Int)
+
+Load the codes from disk for a given chunk index. The codes are stored in the file `<chunk_idx>.codes.jld2` located inside the 
+`index_path` provided by the configuration.
+
+# Arguments
+
+- `codec`: The [`ResidualCodec`](@ref) object containing the compression information.
+- `chunk_idx`: The chunk index for which the codes should be loaded.
+
+# Returns
+
+A vector of codes for the specified chunk.
+"""
 function load_codes(codec::ResidualCodec, chunk_idx::Int)
     codes_path = joinpath(codec.config.indexing_settings.index_path, "$(chunk_idx).codes.jld2")
     codes = load(codes_path, "codes") 

--- a/src/indexing/collection_encoder.jl
+++ b/src/indexing/collection_encoder.jl
@@ -1,5 +1,20 @@
 using ..ColBERT: ColBERTConfig
 
+"""
+    CollectionEncoder(config::ColBERTConfig, checkpoint::Checkpoint)
+
+Structure to represent an encoder used to encode document passages to their corresponding embeddings.
+
+# Arguments
+
+- `config`: The underlying [`ColBERTConfig`](@ref). 
+- `checkpoint`: The [`Checkpoint`](@ref) used by the model.
+
+# Returns
+
+A [`CollectionEncoder`](@ref).
+
+"""
 struct CollectionEncoder
     config::ColBERTConfig
     checkpoint::Checkpoint

--- a/src/indexing/collection_encoder.jl
+++ b/src/indexing/collection_encoder.jl
@@ -20,6 +20,25 @@ struct CollectionEncoder
     checkpoint::Checkpoint
 end
 
+"""
+    encode_passages(encoder::CollectionEncoder, passages::Vector{String})
+
+Encode a list of passages using `encoder`. 
+
+The given `passages` are run through the underlying BERT model and the linear layer to generate the embeddings, after doing relevant document-specific preprocessing. See [`docFromText`](@ref) for more details.
+
+# Arguments
+
+- `encoder`: The encoder used to encode the passages.
+- `passages`: A list of strings representing the passages to be encoded.
+
+# Returns
+
+A tuple `embs, doclens` where:
+
+- `embs::Matrix{Float64}`: The full embedding matrix. Of shape `(D, N)`, where `D` is the embedding dimension and `N` is the total number of embeddings across all the passages. 
+- `doclens::Vector{Int}`: A vector of document lengths for each passage, i.e the total number of attended tokens for each document passage. 
+"""
 function encode_passages(encoder::CollectionEncoder, passages::Vector{String})
     @info "Encoding $(length(passages)) passages."
 

--- a/src/indexing/collection_indexer.jl
+++ b/src/indexing/collection_indexer.jl
@@ -74,7 +74,7 @@ end
 """
     _sample_embeddings(indexer::CollectionIndexer, sampled_pids::Set{Int})
 
-Compute embeddings for the PIDs sampled by [``_sample_pids](@ref), compute the average document length using the embeddings, and save the sampled embeddings to disk.
+Compute embeddings for the PIDs sampled by [`_sample_pids`](@ref), compute the average document length using the embeddings, and save the sampled embeddings to disk.
 
 The embeddings for the sampled documents are saved in a file named `sample.jld2` with it's path specified by the indexing directory. This embedding array has shape `(D, N)`, where `D` is the embedding dimension (`128`, after applying the linear layer of the ColBERT model) and `N` is the total number of embeddings over all documents.
 
@@ -119,14 +119,6 @@ Information about the number of chunks, number of clusters, estimated number of 
 # Arguments
 
 - `indexer`: The `CollectionIndexer` object that contains the index plan to be saved.
-
-# Examples
-
-```julia-repl
-julia> _save_plan(indexer) 
-"Saving the index plan to $(indexer.plan_path)."
-```
-
 """
 function _save_plan(indexer::CollectionIndexer)
     @info "Saving the index plan to $(indexer.plan_path)."

--- a/src/indexing/collection_indexer.jl
+++ b/src/indexing/collection_indexer.jl
@@ -1,5 +1,19 @@
 using .ColBERT: ColBERTConfig, CollectionEncoder, ResidualCodec
 
+"""
+    CollectionIndexer(config::ColBERTConfig, encoder::CollectionEncoder, saver::IndexSaver)
+
+Structure which performs all the index-building operations, including sampling initial centroids, clustering, computing document embeddings, compressing and building the `ivf`.
+
+# Arguments
+- `config`: The [`ColBERTConfig`](@ref) used to build the model. 
+- `encoder`: The [`CollectionEncoder`](@ref) to be used for encoding documents. 
+- `saver`: The [`IndexSaver`](@ref), responsible for saving the index to disk.
+
+# Returns
+
+A [`CollectionIndexer`](@ref) object, containing all indexing-related information. See the [`setup`](@ref), [`train`](@ref), [`index`](@ref) and [`finalize`](@ref) functions for building the index.
+"""
 mutable struct CollectionIndexer
     config::ColBERTConfig
     encoder::CollectionEncoder

--- a/src/indexing/collection_indexer.jl
+++ b/src/indexing/collection_indexer.jl
@@ -173,7 +173,7 @@ Randomly shuffle and split the sampled embeddings.
 The sample embeddings saved by the [`setup`](@ref) function are loaded, shuffled randomly, and then split into a `sample` and a `sample_heldout` set, with `sample_heldout` containing a `0.05` fraction of the original sampled embeddings.
 
 # Arguments
-- `indexer`: The [`CollectionIndexer`](@ref)
+- `indexer`: The [`CollectionIndexer`](@ref).
 
 # Returns
 
@@ -259,6 +259,18 @@ function train(indexer::CollectionIndexer)
     save_codec(indexer.saver)
 end
 
+"""
+    index(indexer::CollectionIndexer; chunksize::Union{Int, Missing} = missing)
+
+Build the index using `indexer`.
+
+The documents are processed in batches of size `chunksize` (see [`enumerate_batches`](@ref)). Embeddings and document lengths are computed for each batch (see [`encode_passages`](@ref)), and they are saved to disk along with relevant metadata (see [`save_chunk`](@ref)).
+
+# Arguments
+
+- `indexer`: The [`CollectionIndexer`](@ref) used to build the index.
+- `chunksize`: Size of a chunk into which the index is to be stored. 
+"""
 function index(indexer::CollectionIndexer; chunksize::Union{Int, Missing} = missing)
     load_codec!(indexer.saver)                  # load the codec objects
     batches = enumerate_batches(indexer.config.resource_settings.collection, chunksize = chunksize, nranks = indexer.config.run_settings.nranks)
@@ -271,6 +283,16 @@ function index(indexer::CollectionIndexer; chunksize::Union{Int, Missing} = miss
     end
 end
 
+"""
+    finalize(indexer::CollectionIndexer)
+
+Finalize the indexing process by saving all files, collecting embedding ID offsets, building IVF, and updating metadata.
+
+See [`_check_all_files_are_saved`](@ref), [`_collect_embedding_id_offset`](@ref), [`_build_ivf`](@ref) and [`_update_metadata`](@ref) for more details.
+
+# Arguments
+- `indexer::CollectionIndexer`: The [`CollectionIndexer`](@ref) used to finalize the indexing process. 
+"""
 function finalize(indexer::CollectionIndexer)
     _check_all_files_are_saved(indexer)
     _collect_embedding_id_offset(indexer)

--- a/src/infra/config.jl
+++ b/src/infra/config.jl
@@ -12,6 +12,63 @@ Structure containing config for running and training various components.
 - `query_settings`: Sets the [`QuerySettings`](@ref).
 - `indexing_settings`: Sets the [`IndexingSettings`](@ref). 
 - `search_settings`: Sets the [`SearchSettings`](@ref).
+
+# Returns
+
+A [`ColBERTConfig`](@ref) object.
+
+# Examples
+
+The relevant files for this example can be found in the `examples/` folder of the project root.
+
+```julia-repl
+julia> dataroot = "downloads/lotte"
+
+julia> dataset = "lifestyle"
+
+julia> datasplit = "dev"
+
+julia> path = joinpath(dataroot, dataset, datasplit, "short_collection.tsv")
+
+julia> collection = Collection(path)
+
+julia> length(collection.data)
+
+julia> nbits = 2   # encode each dimension with 2 bits
+
+julia> doc_maxlen = 300   # truncate passages at 300 tokens
+
+julia> checkpoint = "colbert-ir/colbertv2.0"                       # the HF checkpoint
+
+julia> index_root = "experiments/notebook/indexes"
+
+julia> index_name = "short_\$(dataset).\$(datasplit).\$(nbits)bits"
+
+julia> index_path = joinpath(index_root, index_name)
+
+julia> config = ColBERTConfig(
+            RunSettings(
+                experiment="notebook",
+            ),
+            TokenizerSettings(),
+            ResourceSettings(
+                checkpoint=checkpoint,
+                collection=collection,
+                index_name=index_name,
+            ),
+            DocSettings(
+                doc_maxlen=doc_maxlen,
+            ),
+            QuerySettings(),
+            IndexingSettings(
+                index_path=index_path,
+                index_bsize=3,
+                nbits=nbits,
+                kmeans_niters=20,
+            ),
+            SearchSettings(),
+        );
+```
 """
 Base.@kwdef struct ColBERTConfig
     run_settings::RunSettings

--- a/src/infra/config.jl
+++ b/src/infra/config.jl
@@ -1,3 +1,18 @@
+"""
+    ColBERTConfig(run_settings::RunSettings, tokenizer_settings::TokenizerSettings, resource_settings::ResourceSettings, doc_settings::DocSettings, query_settings::QuerySettings, indexing_settings::IndexingSettings, search_settings::SearchSettings)
+
+Structure containing config for running and training various components.
+
+# Arguments
+
+- `run_settings`: Sets the [`RunSettings`](@ref).
+- `tokenizer_settings`: Sets the [`TokenizerSettings`](@ref).
+- `resource_settings`: Sets the [`ResourceSettings`](@ref). 
+- `doc_settings`: Sets the [`DocSettings`](@ref). 
+- `query_settings`: Sets the [`QuerySettings`](@ref).
+- `indexing_settings`: Sets the [`IndexingSettings`](@ref). 
+- `search_settings`: Sets the [`SearchSettings`](@ref).
+"""
 Base.@kwdef struct ColBERTConfig
     run_settings::RunSettings
     tokenizer_settings::TokenizerSettings

--- a/src/infra/settings.jl
+++ b/src/infra/settings.jl
@@ -1,5 +1,23 @@
 using ..ColBERT: Collection
 
+"""
+    RunSettings([root, experiment, index_root, name, rank, nranks])
+
+Structure holding all the settings necessary to describe the run environment.
+
+# Arguments 
+
+- `root`: The root directory for the run. Default is an `"experiments"` folder in the current working directory.
+- `experiment`: The name of the run. Default is `"default"`.
+- `index_root`: The root directory for storing index. For now, there is no need to specify this as it is determined by the indexing component.
+- `name`: The name of the run. Default is the current date and time.
+- `rank`: The index of the running GPU. Default is `0`. For now, the package only allows this to be `0`.
+- `nranks`: The number of GPUs used in the run. Default is `1`. For now, the package only supports one GPU.
+
+# Returns
+
+A `RunSettings` object.
+"""
 Base.@kwdef struct RunSettings
     root::String = joinpath(pwd(), "experiments")
     experiment::String = "default"
@@ -9,6 +27,22 @@ Base.@kwdef struct RunSettings
     nranks::Int = 1
 end
 
+"""
+    TokenizerSettings([query_token_id, doc_token_id, query_token, doc_token])
+
+Structure to represent settings for the tokenization of queries and documents. 
+
+# Arguments
+
+- `query_token_id`: Unique identifier for query tokens (defaults to `[unused0]`).
+- `doc_token_id`: Unique identifier for document tokens (defaults to `[unused1]`).
+- `query_token`: Token used to represent a query token (defaults to `[Q]`).
+- `doc_token`: Token used to represent a document token (defaults to `[D]`).
+
+# Returns
+
+A `TokenizerSettings` object.
+"""
 Base.@kwdef struct TokenizerSettings
     query_token_id::String = "[unused0]"
     doc_token_id::String = "[unused1]"
@@ -16,6 +50,22 @@ Base.@kwdef struct TokenizerSettings
     doc_token::String = "[D]"
 end
 
+"""
+    ResourceSettings([checkpoint, collection, queries, index_name])
+
+Structure to represent resource settings.
+
+# Arguments 
+
+- `checkpoint`: The path to the HuggingFace checkpoint of the underlying ColBERT model. 
+- `collection`: The underlying collection of documents
+- `queries`: The underlying collection of queries. 
+- `index_name`: The name of the index.
+
+# Returns
+
+A `ResourceSettings` object.
+"""
 Base.@kwdef struct ResourceSettings
     checkpoint::Union{Nothing, String} = nothing
     collection::Union{Nothing, Collection} = nothing
@@ -23,18 +73,63 @@ Base.@kwdef struct ResourceSettings
     index_name::Union{Nothing, String} = nothing
 end
 
+"""
+    DocSettings([dim, doc_maxlen, mask_punctuation])
+
+Structure that defines the settings used for generating document embeddings.
+
+# Arguments 
+
+- `dim`: The dimension of the document embedding space. Default is 128.
+- `doc_maxlen`: The maximum length of a document before it is trimmed to fit. Default is 220.
+- `mask_punctuation`: Whether or not to mask punctuation characters tokens in the document. Default is true.
+
+# Returns
+
+A `DocSettings` object.
+"""
 Base.@kwdef struct DocSettings
     dim::Int = 128
     doc_maxlen::Int = 220
     mask_punctuation::Bool = true
 end
 
+"""
+    QuerySettings([query_maxlen, attend_to_mask_tokens, interaction])
+
+A structure representing the query settings used by the ColBERT model.
+
+# Arguments
+ 
+- `query_maxlen`: The maximum length of queries after which they are trimmed. 
+- `attend_to_mask_tokens`: Whether or not to attend to mask tokens in the query. Default value is false.
+- `interaction`: The type of interaction used to compute the scores for the queries. Default value is "colbert".
+
+# Returns
+
+A `QuerySettings` object.
+"""
 Base.@kwdef struct QuerySettings
     query_maxlen::Int = 32
     attend_to_mask_tokens::Bool = false
     interaction::String = "colbert"
 end
 
+"""
+    IndexingSettings([index_path, index_bsize, nbits, kmeans_niters])
+
+Structure containing settings for indexing.
+
+# Arguments
+- `index_path`: Path to save the index files. 
+- `index_bsize::Int`: Batch size used for some parts of indexing.
+- `nbits::Int`: Number of bits used to compress residuals.
+- `kmeans_niters::Int`: Number of iterations used for k-means clustering.
+
+# Returns
+
+An `IndexingSettings` object.
+"""
 Base.@kwdef struct IndexingSettings
     index_path::Union{Nothing, String} = nothing
     index_bsize::Int = 64

--- a/src/modelling/checkpoint.jl
+++ b/src/modelling/checkpoint.jl
@@ -16,6 +16,8 @@ A [`BaseColBERT`](@ref) object.
 
 # Examples
 
+The `config` in the below example is taken from the example in [`ColBERTConfig`](@ref).
+
 ```julia-repl
 julia> base_colbert = BaseColBERT(checkpoint, config); 
 

--- a/src/modelling/checkpoint.jl
+++ b/src/modelling/checkpoint.jl
@@ -173,17 +173,41 @@ end
     mask_skiplist(tokenizer::Transformers.TextEncoders.AbstractTransformerTextEncoder, integer_ids::AbstractArray, skiplist::Union{Missing, Vector{Int}})
 
 Create a mask for the given `integer_ids`, based on the provided `skiplist`. 
-If the `skiplist` is not missing, then any token ids in the list will be filtered out.
+If the `skiplist` is not missing, then any token IDs in the list will be filtered out along with the padding token.
 Otherwise, all tokens are included in the mask.
 
 # Arguments
 
-- `tokenizer::Transformers.TextEncoders.AbstractTransformerTextEncoder`: The text encoder used to transform the input text into integer ids. 
-- `integer_ids::AbstractArray`: An array of integers representing the encoded tokens. 
-- `skiplist::Union{Missing, Vector{Int}}`: A list of token ids to skip in the mask. If missing, all tokens are included.
+- `tokenizer`: The underlying tokenizer. 
+- `integer_ids`: An `Array` of token IDs for the documents. 
+- `skiplist`: A list of token IDs to skip in the mask. 
 
 # Returns
-An array of booleans indicating whether each token id is included in the mask or not.
+An array of booleans indicating whether the corresponding token ID is included in the mask or not. The array has the same shape as `integer_ids`, i.e `(L, N)`, where `L` is the maximum length of any document in `integer_ids` and `N` is the number of documents.
+
+# Examples
+
+Continuing with the example for [`tensorize`](@ref) and the `skiplist` from the example in [`Checkpoint`](@ref). 
+
+```julia-repl
+julia>  mask_skiplist(checkPoint.model.tokenizer, integer_ids, checkPoint.skiplist)
+14×4 BitMatrix:
+ 1  1  1  1
+ 1  1  1  1
+ 1  1  1  1
+ 1  1  1  1
+ 1  0  0  1
+ 0  1  0  1
+ 0  0  0  1
+ 0  0  0  0
+ 0  0  0  1
+ 0  0  0  1
+ 0  0  0  1
+ 0  0  0  1
+ 0  0  0  1
+ 0  0  0  1
+
+```
 """
 function mask_skiplist(tokenizer::Transformers.TextEncoders.AbstractTransformerTextEncoder, integer_ids::AbstractArray, skiplist::Union{Missing, Vector{Int}})
     if !ismissing(skiplist)

--- a/src/modelling/tokenization/doc_tokenization.jl
+++ b/src/modelling/tokenization/doc_tokenization.jl
@@ -161,6 +161,7 @@ function tensorize(doc_tokenizer::DocTokenizer, tokenizer::Transformers.TextEnco
     ids, mask = encoded_text.token, encoded_text.attention_mask
     integer_ids = reinterpret(Int32, ids)
     integer_mask = NeuralAttentionlib.getmask(mask, ids)[1, :, :]
+    @assert isequal(size(integer_ids), size(integer_mask))
 
     # adding the [D] marker token ID
     integer_ids[2, :] .= doc_tokenizer.D_marker_token_id

--- a/src/modelling/tokenization/doc_tokenization.jl
+++ b/src/modelling/tokenization/doc_tokenization.jl
@@ -1,5 +1,19 @@
 using ...ColBERT: ColBERTConfig
 
+"""
+    DocTokenizer(tokenizer::Transformers.TextEncoders.AbstractTransformerTextEncoder, config::ColBERTConfig)
+
+Construct a `DocTokenizer` from a given tokenizer and configuration. The resulting structure supports functions to perform CoLBERT-style document operations on document texts.  
+
+# Arguments
+
+- `tokenizer`: A tokenizer that has been trained on the BERT vocabulary. Fetched from HuggingFace.
+- `config`: The underlying [`ColBERTConfig`](@ref).
+
+# Returns
+
+A `DocTokenizer` object.
+"""
 struct DocTokenizer
     D_marker_token_id::Int
     config::ColBERTConfig
@@ -10,10 +24,38 @@ function DocTokenizer(tokenizer::Transformers.TextEncoders.AbstractTransformerTe
     DocTokenizer(D_marker_token_id, config)
 end
 
+"""
+    tensorize(doc_tokenizer::DocTokenizer, tokenizer::Transformers.TextEncoders.AbstractTransformerTextEncoder, batch_text::Vector{String}, bsize::Union{Missing, Int})
+
+Convert a collection of documents to tensors in the ColBERT format. 
+
+This function adds the document marker token at the beginning of each document and then converts the text data into integer IDs and masks using the `tokenizer`. The returned objects are determined by the `bsize` argument. More specifically:
+
+- If `bsize` is missing, then a tuple `integer_ids, integer_mask` is returned, where `integer_ids` is an `Array` of token IDs for the modified documents, and `integer_mask` is an `Array` of attention masks for each document.
+- If `bsize` is not missing, then more optimizing operations are performed on the documents. First, the arrays of token IDs and attention masks are sorted by document lengths (this is for more efficient use of GPUs on the batches; see [`_sort_by_length`](@ref)), and a list `reverse_indices` is computed, which remembers the original order of the documents (to reorder them later). The arrays of token IDs and attention masks are then batched into batches of size `bsize` (see [`_split_into_batches`](@ref)). Finally, the batches along with the list of `reverse_indices` are returned.
+
+# Arguments
+
+- `doc_tokenizer`: An instance of the `DocTokenizer` type. This object contains information about the document marker token ID.
+- `tokenizer`: The tokenizer which is used to convert text data into integer IDs.
+- `batch_text`: A document texts that will be converted into tensors of token IDs.
+- `bsize`: The size of the batches to split the `batch_text` into. Can also be `missing`. 
+
+# Returns
+
+If `bsize` is `missing`, then a tuple is returned, which contains: 
+
+- `integer_ids`: An `Array` of integer IDs representing the token IDs of the documents in the input collection.
+- `integer_mask`: An `Array` of bits representing the attention mask for each document. 
+
+If `bsize` is not `missing`, then a tuple containing the following is returned:
+
+- `batches::`: Batches of sorted integer IDs and masks. 
+- `reverse_indices::Vector{Int}`: A vector containing the indices of the documents in their original order.
+"""
 function tensorize(doc_tokenizer::DocTokenizer, tokenizer::Transformers.TextEncoders.AbstractTransformerTextEncoder, batch_text::Vector{String}, bsize::Union{Missing, Int})
     # placeholder for [D] marker token
     batch_text = [". " * doc for doc in batch_text]
-    vocabsize = length(tokenizer.vocab.list)
 
     # getting the integer ids and masks
     encoded_text = Transformers.TextEncoders.encode(tokenizer, batch_text)
@@ -36,12 +78,22 @@ function tensorize(doc_tokenizer::DocTokenizer, tokenizer::Transformers.TextEnco
 end
 
 """
-    _sort_by_length(ids::AbstractMatrix, mask::AbstractMatrix, bsize::Int)
+    _sort_by_length(integer_ids::AbstractMatrix, integer_mask::AbstractMatrix, bsize::Int)
 
-Sort sentences by number of attended tokens, if the number of sentences is larger than bsize. If the number of passages (first dimension of `ids`) is atmost
-than `bsize`, the `ids`, `mask`, and a list `Vector(1:size(ids)[1])` is returned as a three-tuple. Otherwise,
-the passages are first sorted by the number of attended tokens (figured out from `mask`), and then the the sorted arrays
-`ids` and `mask` are returned, along with a reversed list of indices, i.e a mapping from passages to their indice in the sorted list.
+Sort sentences by number of attended tokens, if the number of sentences is larger than `bsize`. 
+
+# Arguments
+
+- `integer_ids`: The token IDs of documents to be sorted.
+- `integer_mask`: The attention masks of the documents to be sorted (attention masks are just bits).
+- `bsize`: The size of batches to be considered.
+
+# Returns
+
+Depending upon `bsize`, the following are returned:
+
+- If the number of documents (second dimension of `integer_ids`) is atmost `bsize`, then the `integer_ids` and `integer_mask` are returned unchanged. 
+- If the number of documents is larger than `bsize`, then the passages are first sorted by the number of attended tokens (figured out from the `integer_mask`), and then the sorted arrays `integer_ids`, `integer_mask` are returned, along with a list of `reverse_indices`, i.e a mapping from the documents to their indices in the original order.
 """
 function _sort_by_length(integer_ids::AbstractMatrix, integer_mask::AbstractMatrix, bsize::Int)
     batch_size = size(integer_ids)[2]
@@ -51,16 +103,25 @@ function _sort_by_length(integer_ids::AbstractMatrix, integer_mask::AbstractMatr
     end
 
     lengths = vec(sum(integer_mask; dims = 1))              # number of attended tokens in each passage
-    indices = sortperm(lengths)                     # get the indices which will sort lengths
-    reverse_indices = sortperm(indices)             # invert the indices list
+    indices = sortperm(lengths)                             # get the indices which will sort lengths
+    reverse_indices = sortperm(indices)                     # invert the indices list
 
     integer_ids[:, indices], integer_mask[:, indices], reverse_indices
 end
 
 """
-    _split_into_batches(integer_ids::AbstractArray, integer_mask::AbstractMatrix, bsize::Int)::Vector{Tuple{AbstractArray, AbstractMatrix, Int}}
+    _split_into_batches(integer_ids::AbstractArray, integer_mask::AbstractMatrix, bsize::Int)
 
 Split the given `integer_ids` and `integer_mask` into batches of size `bsize`.
+
+# Arguments
+
+- `integer_ids`: The array of token IDs to batch. 
+- `integer_mask`: The array of attention masks to batch.
+
+# Returns
+
+Batches of token IDs and attention masks, with each batch having size `bsize` (with the possibility of the last batch being smaller).
 """
 function _split_into_batches(integer_ids::AbstractArray, integer_mask::AbstractMatrix, bsize::Int)
     batch_size = size(integer_ids)[2]
@@ -70,12 +131,3 @@ function _split_into_batches(integer_ids::AbstractArray, integer_mask::AbstractM
     end
     batches
 end
-
-# tokenizer = base_colbert.tokenizer
-# batch_text = [
-#     "hello world",
-#     "thank you!",
-#     "a",
-#     "this is some longer text, so length should be longer",
-# ]
-# bsize = 2

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -1,3 +1,18 @@
+"""
+    batch(group::Vector, bsize::Int; [provide_offset::Bool = false])
+
+Create batches of data from `group`.
+
+Each batch is a subvector of `group` with length equal to `bsize`. If `provide_offset` is true, each batch will be a tuple containing both the offset and the subvector, otherwise only the subvector will be returned.
+
+# Arguments
+- `group::Vector`: The input vector from which to create batches.
+- `bsize::Int`: The size of each batch.
+- `provide_offset::Bool = false`: Whether to include the offset in the output batches. Defaults to `false`.
+
+# Returns
+A vector of tuples, where each tuple contains an offset and a subvector, or just a vector containing subvectors, depending on the value of `provide_offset`.
+"""
 function batch(group::Vector, bsize::Int; provide_offset::Bool = false)
     vtype = provide_offset ? 
         Vector{Tuple{Int, typeof(group)}} :


### PR DESCRIPTION
This PR just adds some needed examples and documentation for the data, indexing types and their associated functions.

- [x] [`collection.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/data/collection.jl)
- [x] [`residual.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/indexing/codecs/residual.jl)
- [x] [`collection_encoder.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/indexing/collection_encoder.jl)
- [x] [`collection_indexer.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/indexing/collection_indexer.jl)
- [x] [`index_saver.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/indexing/index_saver.jl)
- [x] [`config.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/infra/config.jl)
- [x] [`settings.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/infra/settings.jl)
- [x] [`checkpoint.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/modelling/checkpoint.jl)
- [x] [`doc_tokenization.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/modelling/tokenization/doc_tokenization.jl)
- [x] [`utils.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/utils/utils.jl)
~~[`ColBERT.jl`](https://github.com/codetalker7/ColBERT.jl/blob/main/src/ColBERT.jl)~~