### PR TITLE
Fixing indexing code to include `QueryTokenizer` in the `Checkpoint`.

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -17,7 +17,7 @@ function index(indexer::Indexer)
     # loading the models
     @info "Loading ColBERT layers from HuggingFace."
     base_colbert = BaseColBERT(checkpoint, config)
-    checkPoint = Checkpoint(base_colbert, DocTokenizer(base_colbert.tokenizer, config), config)
+    checkPoint = Checkpoint(base_colbert, DocTokenizer(base_colbert.tokenizer, config), QueryTokenizer(base_colbert.tokenizer, config), config)
 
     # creating the encoder, saver and indexer
     encoder = CollectionEncoder(config, checkPoint)


### PR DESCRIPTION
https://github.com/codetalker7/ColBERT.jl/pull/17 changed the `Checkpoint` struct to include a `QueryTokenizer`; this PR fixes the indexing code to include it as well.