### PR TITLE
Exporting the config.

### DIFF
--- a/src/infra/config.jl
+++ b/src/infra/config.jl
@@ -79,3 +79,9 @@ Base.@kwdef struct ColBERTConfig
     indexing_settings::IndexingSettings
     search_settings::SearchSettings
 end
+
+# TODO: need to think of a better way to save the config later.
+function save(config::ColBERTConfig)
+    config_path = joinpath(config.indexing_settings.index_path, "config.jld2")
+    JLD2.save(config_path, Dict("config" => config))
+end


### PR DESCRIPTION
For now, we're just exporting the raw config as-is using `JLD2`. Later we should think of better options to do this.